### PR TITLE
Fixed the duplicate dce_to_r1eff

### DIFF
--- a/src/original/OG_MO_AUMC_ICR_RMH/ExtendedTofts/DCE.py
+++ b/src/original/OG_MO_AUMC_ICR_RMH/ExtendedTofts/DCE.py
@@ -142,7 +142,7 @@ def enhance(signal,delay=20,sds=1,percentage=10):
     selected = np.sum(selects,1) < (percentage/100*(np.shape(signal)[1]-delay-5))
     return selected
 
-def dce_to_r1eff(S, R1, TR, flip):
+def dce_to_r1eff(S, R1, TR, flip, baseline_time=9):
     """
     Go from DCE seignal over time to R1 over time.
 
@@ -153,7 +153,7 @@ def dce_to_r1eff(S, R1, TR, flip):
 
     :return : The selected enhancing voxel indices
     """
-    S0 = np.mean(S[:,0:9],axis=1)*(1-np.exp(-R1*TR)*cos(flip)) / \
+    S0 = np.mean(S[:,1:baseline_time],axis=1)*(1-np.exp(-R1*TR)*cos(flip)) / \
          (sin(flip)*(1-np.exp(-TR*R1)))
     S0 = np.repeat(np.expand_dims(S0,axis=1),np.shape(S)[1],axis=1)
     return - log((S0*sin(flip) - S)/(S0*sin(flip)-S*cos(flip)))/TR
@@ -304,36 +304,6 @@ def R1_two_fas(images, flip_angles, TR):
                 R1map[j] = 0
                 print(j)
     return (R1map)
-
-def dce_to_r1eff(S, S0, R1, TR, flip):
-    #taken from https://github.com/welcheb/pydcemri/blob/master from David S. Smith
-    # Copyright (C) 2014   David S. Smith
-    #
-    # This program is free software; you can redistribute it and/or modify
-    # it under the terms of the GNU General Public License as published by
-    # the Free Software Foundation; either version 2 of the License, or
-    # (at your option) any later version.
-    #
-    # This program is distributed in the hope that it will be useful,
-    # but WITHOUT ANY WARRANTY; without even the implied warranty of
-    # MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-    # GNU General Public License for more details.
-    #
-    # You should have received a copy of the GNU General Public License along
-    # with this program; if not, write to the Free Software Foundation, Inc.,
-    # 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
-    #
-    print('converting DCE signal to effective R1')
-    assert(flip > 0.0)
-    assert(TR > 0.0 and TR < 1.0)
-    S = S.T
-    S0 = np.repeat(np.expand_dims(S0,axis=1),len(S),axis=1).T
-    A = S / S0  # normalize by pre-contrast signal
-    E0 = exp(-R1 * TR)
-    E = (1.0 - A + A*E0 - E0*cos(flip)) /\
-         (1.0 - A*cos(flip) + A*E0*cos(flip) - E0*cos(flip))
-    R = (-1.0 / TR) * log(E)
-    return R.T
 
 def r1eff_to_conc(R1eff, R1map, relaxivity):
     return (R1eff - R1map) / relaxivity

--- a/src/original/OG_MO_AUMC_ICR_RMH/ExtendedTofts/sim_lsq.py
+++ b/src/original/OG_MO_AUMC_ICR_RMH/ExtendedTofts/sim_lsq.py
@@ -135,7 +135,7 @@ sigT1 = np.transpose([np.sqrt(np.mean(np.square(dce_signal_noisy[:, 0:rep1]), 1)
 R1map = dce.R1_two_fas(sigT1, flip_angles, hp.acquisition.TR)
 S0 = np.mean(dce_signal_noisy[:, rep1:rep1 + 10], axis=1)
 # with baseline R1 and S0 we can estimate R1 over time (effected by the contrast agent arriving)
-R1eff2 = dce.dce_to_r1eff(dce_signal_noisy[:, rep1:], S0, R1map, hp.acquisition.TR, hp.acquisition.FA2)
+R1eff2 = dce.dce_to_r1eff(dce_signal_noisy[:, rep1:], R1map, hp.acquisition.TR, hp.acquisition.FA2, baseline_time=9)
 
 C1 = dce.r1eff_to_conc(R1eff2, np.transpose([R1map]), hp.acquisition.r1)
 del sigT1, R1map, S0, R1eff2

--- a/test/SI_to_Conc/test_SI2Conc_OG_MO_AUMC_ICR_RMH.py
+++ b/test/SI_to_Conc/test_SI2Conc_OG_MO_AUMC_ICR_RMH.py
@@ -23,16 +23,13 @@ def test_OG_MO_AUMC_ICR_RMH_dce_to_r1eff(label, fa, tr, T1base, BLpts, r1, s_arr
     fa_rad=fa * np.pi/180.
     #This function uses a value for S0, which would be the mean of the s_array from 1 to BLpts.
     # It's from 1 rather than 0 because the code used to do the original conversion skips the first point of the SI curve
-    s0=np.mean(s_array[1:BLpts])
-
-    #This function expects a signal array of shape (x,1) rather than (x,) s0 add another dimension to the signal array to make it (150,1) rather than (150,) 
+    #This function expects a signal array of shape (x,1) rather than (x,) s0 add another dimension to the signal array to make it (150,1) rather than (150,)
     s_array=s_array[:,None].T
     
     # run test
     #The code uses two functions to get from SI to conc
-    r1_curve = dce_to_r1eff(s_array, [s0], 1/T1base, tr, fa_rad)
+    r1_curve = dce_to_r1eff(s_array, 1/T1base, tr, fa_rad, baseline_time=BLpts)
     conc_curve = r1eff_to_conc(r1_curve, 1/T1base, r1)
-
 
     np.testing.assert_allclose( conc_curve, [conc_array], rtol=r_tol, atol=a_tol )
 


### PR DESCRIPTION
OG_MO_AUMC_ICR_RMH had two versions of dce_to_r1eff, which I now reduced to 1.