### PR TITLE
Fix: Install notebook dependencies before running notebook steps

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -46,11 +46,11 @@ jobs:
     - name: Convert contributors csv to md
       if: env.CONTINUE == 'true'
       run: |
+        pip install -r notebooks/requirements.txt
         python doc/convert_to_md.py
     - name: Build the book
       if: env.CONTINUE == 'true'
       run: |
-        pip install -r notebooks/requirements.txt
         jupyter-book build notebooks/
         touch notebooks/_build/html/.nojekyll
     - name: Re-organize files


### PR DESCRIPTION
Fixes bug from #131 where notebook part of the github action was failing 

Since the action doesn't run on forks or pull request, this has to be merged into develop first to see if it works.
