### PR TITLE
Fix #86: Add fitting_method to metadata and clean author names

### DIFF
--- a/notebooks/2CUM.ipynb
+++ b/notebooks/2CUM.ipynb
@@ -144,12 +144,16 @@
     "df = []\n",
     "for entry in meta:\n",
     "    if (entry['category'] == 'DCEmodels') & (entry['method'] == '2CUM') :\n",
-    "        fpath, fname, category, method, author = entry.values()\n",
-    "        df_entry = pd.read_csv(Path(fpath, fname)).assign(author=author)\n",
+    "        fpath, fname, category, method, author, fitting_method = entry.values()\n",
+    "        df_entry = pd.read_csv(Path(fpath, fname)).assign(author=author, fitting_method=fitting_method)\n",
     "        df.append(df_entry)\n",
     "    \n",
     "# Concat all entries\n",
-    "df = pd.concat(df)"
+    "df = pd.concat(df)\n",
+     "# Build contribution_id: author + fitting_method (if any)\n",
+     "df['contribution_id'] = df.apply(\n",
+     "    lambda r: f\"{r['author']} ({r['fitting_method']})\" if r['fitting_method'] else r['author'],\n",
+     "    axis=1)"
    ]
   },
   {

--- a/notebooks/2CXM.ipynb
+++ b/notebooks/2CXM.ipynb
@@ -145,12 +145,16 @@
     "df = []\n",
     "for entry in meta:\n",
     "    if (entry['category'] == 'DCEmodels') & (entry['method'] == '2CXM') :\n",
-    "        fpath, fname, category, method, author = entry.values()\n",
-    "        df_entry = pd.read_csv(Path(fpath, fname)).assign(author=author)\n",
+    "        fpath, fname, category, method, author, fitting_method = entry.values()\n",
+    "        df_entry = pd.read_csv(Path(fpath, fname)).assign(author=author, fitting_method=fitting_method)\n",
     "        df.append(df_entry)\n",
     "    \n",
     "# Concat all entries\n",
-    "df = pd.concat(df)"
+    "df = pd.concat(df)\n",
+     "# Build contribution_id: author + fitting_method (if any)\n",
+     "df['contribution_id'] = df.apply(\n",
+     "    lambda r: f\"{r['author']} ({r['fitting_method']})\" if r['fitting_method'] else r['author'],\n",
+     "    axis=1)"
    ]
   },
   {

--- a/notebooks/DSC_pars.ipynb
+++ b/notebooks/DSC_pars.ipynb
@@ -154,12 +154,16 @@
     "df = []\n",
     "for entry in meta:\n",
     "    if (entry['category'] == 'DSCmodels'):\n",
-    "        fpath, fname, category, method, author = entry.values()\n",
-    "        df_entry = pd.read_csv(Path(fpath, fname)).assign(author=author)\n",
+    "        fpath, fname, category, method, author, fitting_method = entry.values()\n",
+    "        df_entry = pd.read_csv(Path(fpath, fname)).assign(author=author, fitting_method=fitting_method)\n",
     "        df.append(df_entry)\n",
     "    \n",
     "# Concat all entries\n",
-    "df = pd.concat(df)"
+    "df = pd.concat(df)\n",
+     "# Build contribution_id: author + fitting_method (if any)\n",
+     "df['contribution_id'] = df.apply(\n",
+     "    lambda r: f\"{r['author']} ({r['fitting_method']})\" if r['fitting_method'] else r['author'],\n",
+     "    axis=1)"
    ]
   },
   {

--- a/notebooks/ExtendedToftsModel.ipynb
+++ b/notebooks/ExtendedToftsModel.ipynb
@@ -191,12 +191,16 @@
     "df = []\n",
     "for entry in meta:\n",
     "    if (entry['category'] == 'DCEmodels') & (entry['method'] == 'etofts') :\n",
-    "        fpath, fname, category, method, author = entry.values()\n",
-    "        df_entry = pd.read_csv(Path(fpath, fname)).assign(author=author)\n",
+    "        fpath, fname, category, method, author, fitting_method = entry.values()\n",
+    "        df_entry = pd.read_csv(Path(fpath, fname)).assign(author=author, fitting_method=fitting_method)\n",
     "        df.append(df_entry)\n",
     "\n",
     "# Concat all entries\n",
-    "df = pd.concat(df)"
+    "df = pd.concat(df)\n",
+     "# Build contribution_id: author + fitting_method (if any)\n",
+     "df['contribution_id'] = df.apply(\n",
+     "    lambda r: f\"{r['author']} ({r['fitting_method']})\" if r['fitting_method'] else r['author'],\n",
+     "    axis=1)"
    ]
   },
   {

--- a/notebooks/GeorgiouAIF.ipynb
+++ b/notebooks/GeorgiouAIF.ipynb
@@ -90,12 +90,16 @@
     "df = []\n",
     "for entry in meta:\n",
     "    if (entry['category'] == 'PopulationAIF') & (entry['method'] == 'Georgiou') :\n",
-    "        fpath, fname, category, method, author = entry.values()\n",
-    "        df_entry = pd.read_csv(Path(fpath, fname)).assign(author=author)\n",
+    "        fpath, fname, category, method, author, fitting_method = entry.values()\n",
+    "        df_entry = pd.read_csv(Path(fpath, fname)).assign(author=author, fitting_method=fitting_method)\n",
     "        df.append(df_entry)\n",
     "    \n",
     "# Concat all entries\n",
-    "df = pd.concat(df)"
+    "df = pd.concat(df)\n",
+     "# Build contribution_id: author + fitting_method (if any)\n",
+     "df['contribution_id'] = df.apply(\n",
+     "    lambda r: f\"{r['author']} ({r['fitting_method']})\" if r['fitting_method'] else r['author'],\n",
+     "    axis=1)"
    ]
   },
   {

--- a/notebooks/ParkerAIF.ipynb
+++ b/notebooks/ParkerAIF.ipynb
@@ -91,12 +91,16 @@
     "df = []\n",
     "for entry in meta:\n",
     "    if (entry['category'] == 'PopulationAIF') & (entry['method'] == 'Parker') :\n",
-    "        fpath, fname, category, method, author = entry.values()\n",
-    "        df_entry = pd.read_csv(Path(fpath, fname)).assign(author=author)\n",
+    "        fpath, fname, category, method, author, fitting_method = entry.values()\n",
+    "        df_entry = pd.read_csv(Path(fpath, fname)).assign(author=author, fitting_method=fitting_method)\n",
     "        df.append(df_entry)\n",
     "    \n",
     "# Concat all entries\n",
-    "df = pd.concat(df)"
+    "df = pd.concat(df)\n",
+     "# Build contribution_id: author + fitting_method (if any)\n",
+     "df['contribution_id'] = df.apply(\n",
+     "    lambda r: f\"{r['author']} ({r['fitting_method']})\" if r['fitting_method'] else r['author'],\n",
+     "    axis=1)"
    ]
   },
   {

--- a/notebooks/PatlakModel.ipynb
+++ b/notebooks/PatlakModel.ipynb
@@ -139,12 +139,16 @@
     "df = []\n",
     "for entry in meta:\n",
     "    if (entry['category'] == 'DCEmodels') & (entry['method'] == 'patlak') :\n",
-    "        fpath, fname, category, method, author = entry.values()\n",
-    "        df_entry = pd.read_csv(Path(fpath, fname)).assign(author=author)\n",
+    "        fpath, fname, category, method, author, fitting_method = entry.values()\n",
+    "        df_entry = pd.read_csv(Path(fpath, fname)).assign(author=author, fitting_method=fitting_method)\n",
     "        df.append(df_entry)\n",
     "    \n",
     "# Concat all entries\n",
-    "df = pd.concat(df)"
+    "df = pd.concat(df)\n",
+     "# Build contribution_id: author + fitting_method (if any)\n",
+     "df['contribution_id'] = df.apply(\n",
+     "    lambda r: f\"{r['author']} ({r['fitting_method']})\" if r['fitting_method'] else r['author'],\n",
+     "    axis=1)"
    ]
   },
   {

--- a/notebooks/PreclinicalAIF.ipynb
+++ b/notebooks/PreclinicalAIF.ipynb
@@ -93,12 +93,16 @@
     "df = []\n",
     "for entry in meta:\n",
     "    if (entry['category'] == 'PopulationAIF') & (entry['method'] == 'preclinical') :\n",
-    "        fpath, fname, category, method, author = entry.values()\n",
-    "        df_entry = pd.read_csv(Path(fpath, fname)).assign(author=author)\n",
+    "        fpath, fname, category, method, author, fitting_method = entry.values()\n",
+    "        df_entry = pd.read_csv(Path(fpath, fname)).assign(author=author, fitting_method=fitting_method)\n",
     "        df.append(df_entry)\n",
     "    \n",
     "# Concat all entries\n",
-    "df = pd.concat(df)"
+    "df = pd.concat(df)\n",
+     "# Build contribution_id: author + fitting_method (if any)\n",
+     "df['contribution_id'] = df.apply(\n",
+     "    lambda r: f\"{r['author']} ({r['fitting_method']})\" if r['fitting_method'] else r['author'],\n",
+     "    axis=1)"
    ]
   },
   {

--- a/notebooks/SItoC.ipynb
+++ b/notebooks/SItoC.ipynb
@@ -128,12 +128,16 @@
     "df = []\n",
     "for entry in meta:\n",
     "    if entry['category'] == 'SI_to_Conc':\n",
-    "        fpath, fname, category, method, author = entry.values()\n",
-    "        df_entry = pd.read_csv(Path(fpath, fname)).assign(author=author)\n",
+    "        fpath, fname, category, method, author, fitting_method = entry.values()\n",
+    "        df_entry = pd.read_csv(Path(fpath, fname)).assign(author=author, fitting_method=fitting_method)\n",
     "        df.append(df_entry)\n",
     "    \n",
     "# Concat all entries\n",
-    "df = pd.concat(df)"
+    "df = pd.concat(df)\n",
+     "# Build contribution_id: author + fitting_method (if any)\n",
+     "df['contribution_id'] = df.apply(\n",
+     "    lambda r: f\"{r['author']} ({r['fitting_method']})\" if r['fitting_method'] else r['author'],\n",
+     "    axis=1)"
    ]
   },
   {

--- a/notebooks/ToftsModel.ipynb
+++ b/notebooks/ToftsModel.ipynb
@@ -171,12 +171,16 @@
     "df = []\n",
     "for entry in meta:\n",
     "    if (entry['category'] == 'DCEmodels') & (entry['method'] == 'tofts') :\n",
-    "        fpath, fname, category, method, author = entry.values()\n",
-    "        df_entry = pd.read_csv(Path(fpath, fname)).assign(author=author)\n",
+    "        fpath, fname, category, method, author, fitting_method = entry.values()\n",
+    "        df_entry = pd.read_csv(Path(fpath, fname)).assign(author=author, fitting_method=fitting_method)\n",
     "        df.append(df_entry)\n",
     "    \n",
     "# Concat all entries\n",
-    "df = pd.concat(df)"
+    "df = pd.concat(df)\n",
+     "# Build contribution_id: author + fitting_method (if any)\n",
+     "df['contribution_id'] = df.apply(\n",
+     "    lambda r: f\"{r['author']} ({r['fitting_method']})\" if r['fitting_method'] else r['author'],\n",
+     "    axis=1)"
    ]
   },
   {

--- a/notebooks/VariableFlipAngle.ipynb
+++ b/notebooks/VariableFlipAngle.ipynb
@@ -127,12 +127,16 @@
     "df = []\n",
     "for entry in meta:\n",
     "    if entry['category'] == 'T1mapping':\n",
-    "        fpath, fname, category, method, author = entry.values()\n",
+    "        fpath, fname, category, method, author, fitting_method = entry.values()\n",
     "        df_entry = pd.read_csv(Path(fpath, fname)).assign(method=method, author=author)\n",
     "        df.append(df_entry)\n",
     "    \n",
     "# Concat all entries\n",
-    "df = pd.concat(df)"
+    "df = pd.concat(df)\n",
+     "# Build contribution_id: author + fitting_method (if any)\n",
+     "df['contribution_id'] = df.apply(\n",
+     "    lambda r: f\"{r['author']} ({r['fitting_method']})\" if r['fitting_method'] else r['author'],\n",
+     "    axis=1)"
    ]
   },
   {

--- a/notebooks/plotting_results_nb.py
+++ b/notebooks/plotting_results_nb.py
@@ -105,11 +105,25 @@ def make_catplot(x, y, data, ylabel, **plotopts):
     g.set_ylabels(ylabel, clear_inner=False);
     g.set_xticklabels(rotation=45, fontsize=16, ha='right', rotation_mode='anchor')
     g._legend.set_title('ContributionID')
-    # Add vertical add midpoints between each major tick
+    # Add vertical grid lines at midpoints between each major tick
     for ax in g.axes.flatten():
         ax.xaxis.set_minor_locator(AutoMinorLocator(2))
         ax.grid(which="minor", axis='x', linestyle=":")
         # Hide the minor ticks (distracting) by making it white
         ax.tick_params(axis='x', which='minor', colors='white')
     plt.show() # Could also do `return g` for more flexibility
-    
+
+
+def make_contribution_label(row):
+    """Build a display label combining author and fitting method.
+
+    For contributions where a fitting method is specified in the metadata,
+    this appends the fitting method to the author name so that different
+    fitting approaches from the same author are displayed separately in plots.
+
+    :param row: a pandas Series (one row of the dataframe)
+    :return: string label, e.g. 'OGJ_OsloU_Norway (LLSQ)'
+    """
+    if 'fitting_method' in row and row['fitting_method']:
+        return f"{row['author']} ({row['fitting_method']})"
+    return row['author']

--- a/test/results-meta.json
+++ b/test/results-meta.json
@@ -4,321 +4,367 @@
     "filename": "TestResults_T1mapping_ZA_McGill_CAN_t1_VFA_lin.csv",
     "category": "T1mapping",
     "method": "linear",
-    "author": "ZA_McGill_CAN"
+    "author": "ZA_McGill_CAN",
+    "fitting_method": ""
   },
   {
     "path": "../test/results/T1_mapping",
     "filename": "TestResults_T1mapping_MJT_Edinburgh_UK_t1_VFA_lin.csv",
     "category": "T1mapping",
     "method": "linear",
-    "author": "MJT_UoEdinburgh_UK"
+    "author": "MJT_UoEdinburgh_UK",
+    "fitting_method": ""
   },
   {
     "path": "../test/results/T1_mapping",
     "filename": "TestResults_T1mapping_MJT_Edinburgh_UK_t1_VFA_2fa.csv",
     "category": "T1mapping",
     "method": "two-FA",
-    "author": "MJT_UoEdinburgh_UK"
+    "author": "MJT_UoEdinburgh_UK",
+    "fitting_method": ""
   },
   {
     "path": "../test/results/T1_mapping",
     "filename": "TestResults_T1mapping_ST_USyd_AUS_t1_VFA_lin.csv",
     "category": "T1mapping",
     "method": "linear",
-    "author": "ST_USyd_Aus"
+    "author": "ST_USyd_Aus",
+    "fitting_method": ""
   },
   {
     "path": "../test/results/T1_mapping",
     "filename": "TestResults_T1mapping_OG_MO_AUMC_ICR_RHM_NL_UK_t1_VFA_2fa.csv",
     "category": "T1mapping",
     "method": "two-FA",
-    "author": "OG_MO_AUMC_NL_ICR_UK"
+    "author": "OG_MO_AUMC_NL_ICR_UK",
+    "fitting_method": ""
   },
   {
     "path": "../test/results/T1_mapping",
     "filename": "TestResults_T1mapping_ZA_McGill_CAN_t1_novifast.csv",
     "category": "T1mapping",
     "method": "nonlinear",
-    "author": "ZA_McGill_CAN"
+    "author": "ZA_McGill_CAN",
+    "fitting_method": ""
   },
   {
     "path": "../test/results/T1_mapping",
     "filename": "TestResults_T1mapping_MJT_Edinburgh_UK_t1_VFA_nonlin.csv",
     "category": "T1mapping",
     "method": "nonlinear",
-    "author": "MJT_UoEdinburgh_UK"
+    "author": "MJT_UoEdinburgh_UK",
+    "fitting_method": ""
   },
   {
     "path": "../test/results/T1_mapping",
     "filename": "TestResults_T1mapping_ST_USyd_AUS_t1_VFA_nonlin.csv",
     "category": "T1mapping",
     "method": "nonlinear",
-    "author": "ST_USyd_Aus"
+    "author": "ST_USyd_Aus",
+    "fitting_method": ""
   },
   {
     "path": "../test/results/T1_mapping",
     "filename": "TestResults_T1mapping_OG_MO_AUMC_ICR_RHM_NL_UK_t1_VFA_nonlin.csv",
     "category": "T1mapping",
     "method": "nonlinear",
-    "author": "OG_MO_AUMC_NL_ICR_UK"
+    "author": "OG_MO_AUMC_NL_ICR_UK",
+    "fitting_method": ""
   },
   {
     "path": "../test/results/SI_to_Conc",
     "filename": "TestResults_SI2Conc_LCB_BNI_USA.csv",
     "category": "SI_to_Conc",
     "method": "",
-    "author": "LCB_BNI_USA"
+    "author": "LCB_BNI_USA",
+    "fitting_method": ""
   },
   {
     "path": "../test/results/SI_to_Conc",
     "filename": "TestResults_SI2Conc_LEK_UoEdinburgh_UK.csv",
     "category": "SI_to_Conc",
     "method": "",
-    "author": "LEK_UoEdinburgh_UK"
+    "author": "LEK_UoEdinburgh_UK",
+    "fitting_method": ""
   },
   {
     "path": "../test/results/SI_to_Conc",
     "filename": "TestResults_SI2Conc_MB_UoManchester_UK.csv",
     "category": "SI_to_Conc",
     "method": "",
-    "author": "MB_UoManchester_UK"
+    "author": "MB_UoManchester_UK",
+    "fitting_method": ""
   },
   {
     "path": "../test/results/SI_to_Conc",
     "filename": "TestResults_SI2Conc_MJT_UoEdinburgh_UK.csv",
     "category": "SI_to_Conc",
     "method": "",
-    "author": "MJT_UoEdinburgh_UK"
+    "author": "MJT_UoEdinburgh_UK",
+    "fitting_method": ""
   },
   {
     "path": "../test/results/SI_to_Conc",
     "filename": "TestResults_SI2Conc_MJT_UoEdinburgh_UK_num.csv",
     "category": "SI_to_Conc",
     "method": "",
-    "author": "MJT_UoEdinburgh_UK_num"
+    "author": "MJT_UoEdinburgh_UK_num",
+    "fitting_method": ""
   },
   {
     "path": "../test/results/SI_to_Conc",
     "filename": "TestResults_SI2Conc_OG_MO_AUMC_ICR_RMH_NL_UK.csv",
     "category": "SI_to_Conc",
     "method": "",
-    "author": "OG_MO_AUMC_NL_ICR_RMH_UK"
+    "author": "OG_MO_AUMC_NL_ICR_RMH_UK",
+    "fitting_method": ""
   },
   {
     "path": "../test/results/SI_to_Conc",
     "filename": "TestResults_SI2Conc_ST_USyd_AUS.csv",
     "category": "SI_to_Conc",
     "method": "",
-    "author": "ST_USyd_Aus"
+    "author": "ST_USyd_Aus",
+    "fitting_method": ""
   },
   {
     "path": "../test/results/PopulationAIF_DCE",
     "filename": "TestResults_PopAIF_Parker_AIF_MJT_Edinburgh_UK.csv",
     "category": "PopulationAIF",
     "method": "Parker",
-    "author": "MJT_UoEdinburgh_UK"
+    "author": "MJT_UoEdinburgh_UK",
+    "fitting_method": ""
   },
   {
     "path": "../test/results/PopulationAIF_DCE",
     "filename": "TestResults_PopAIF_Parker_AIF_MB_QBI_UoManchester_UK.csv",
     "category": "PopulationAIF",
     "method": "Parker",
-    "author": "MB_QBI_UoManchester_UK"
+    "author": "MB_QBI_UoManchester_UK",
+    "fitting_method": ""
   },
   {
     "path": "../test/results/PopulationAIF_DCE",
     "filename": "TestResults_PopAIF_Parker_AIF_PvH_NKI_NL.csv",
     "category": "PopulationAIF",
     "method": "Parker",
-    "author": "PvH_NKI_NL"
+    "author": "PvH_NKI_NL",
+    "fitting_method": ""
   },
   {
     "path": "../test/results/PopulationAIF_DCE",
     "filename": "TestResults_PopAIF_Parker_AIF_ST_USyd_AUS.csv",
     "category": "PopulationAIF",
     "method": "Parker",
-    "author": "ST_USyd_Aus"
+    "author": "ST_USyd_Aus",
+    "fitting_method": ""
   },
   {
     "path": "../test/results/PopulationAIF_DCE",
     "filename": "TestResults_PopAIF_Georgiou_AIF_PvH_NKI_NL.csv",
     "category": "PopulationAIF",
     "method": "Georgiou",
-    "author": "PvH_NKI_NL"
+    "author": "PvH_NKI_NL",
+    "fitting_method": ""
   },
   {
     "path": "../test/results/PopulationAIF_DCE",
     "filename": "TestResults_PopAIF_preclinical_AIF_ST_USyd_AUS.csv",
     "category": "PopulationAIF",
     "method": "preclinical",
-    "author": "ST_USyd_Aus"
+    "author": "ST_USyd_Aus",
+    "fitting_method": ""
   },
   {
     "path": "../test/results/DCEmodels",
     "filename": "TestResults_models_LCB_BNI_USA_tofts.csv",
     "category": "DCEmodels",
     "method": "tofts",
-    "author": "LCB_BNI_USA"
+    "author": "LCB_BNI_USA",
+    "fitting_method": ""
   },
   {
     "path": "../test/results/DCEmodels",
     "filename": "TestResults_models_LEK_UoEdinburgh_UK_etofts.csv",
     "category": "DCEmodels",
     "method": "etofts",
-    "author": "LEK_UoEdinburgh_UK"
+    "author": "LEK_UoEdinburgh_UK",
+    "fitting_method": ""
   },
   {
     "path": "../test/results/DCEmodels",
     "filename": "TestResults_models_LEK_UoEdinburgh_UK_patlak.csv",
     "category": "DCEmodels",
     "method": "patlak",
-    "author": "LEK_UoEdinburgh_UK"
+    "author": "LEK_UoEdinburgh_UK",
+    "fitting_method": ""
   },
   {
     "path": "../test/results/DCEmodels",
     "filename": "TestResults_models_LEK_UoEdinburgh_UK_tofts.csv",
     "category": "DCEmodels",
     "method": "tofts",
-    "author": "LEK_UoEdinburgh_UK"
+    "author": "LEK_UoEdinburgh_UK",
+    "fitting_method": ""
   },
-    {
+  {
     "path": "../test/results/DCEmodels",
     "filename": "TestResults_models_LEK_UoEdinburgh_UK_2CUM.csv",
     "category": "DCEmodels",
     "method": "2CUM",
-    "author": "LEK_UoEdinburgh_UK"
+    "author": "LEK_UoEdinburgh_UK",
+    "fitting_method": ""
   },
-    {
+  {
     "path": "../test/results/DCEmodels",
     "filename": "TestResults_models_LEK_UoEdinburgh_UK_2CXM.csv",
     "category": "DCEmodels",
     "method": "2CXM",
-    "author": "LEK_UoEdinburgh_UK"
+    "author": "LEK_UoEdinburgh_UK",
+    "fitting_method": ""
   },
   {
     "path": "../test/results/DCEmodels",
     "filename": "TestResults_models_MB_QBI_UoManchester_UK_etofts.csv",
     "category": "DCEmodels",
     "method": "etofts",
-    "author": "MB_QBI_UoManchester"
+    "author": "MB_QBI_UoManchester",
+    "fitting_method": ""
   },
   {
     "path": "../test/results/DCEmodels",
     "filename": "TestResults_models_MB_QBI_UoManchester_UK_2CXM.csv",
     "category": "DCEmodels",
     "method": "2CXM",
-    "author": "MB_QBI_UoManchester"
+    "author": "MB_QBI_UoManchester",
+    "fitting_method": ""
   },
   {
     "path": "../test/results/DCEmodels",
     "filename": "TestResults_models_MJT_UoEdinburgh_UK_2CUM.csv",
     "category": "DCEmodels",
     "method": "2CUM",
-    "author": "MJT_UoEdinburgh_UK"
+    "author": "MJT_UoEdinburgh_UK",
+    "fitting_method": ""
   },
   {
     "path": "../test/results/DCEmodels",
     "filename": "TestResults_models_MJT_UoEdinburgh_UK_2CXM.csv",
     "category": "DCEmodels",
     "method": "2CXM",
-    "author": "MJT_UoEdinburgh_UK"
+    "author": "MJT_UoEdinburgh_UK",
+    "fitting_method": ""
   },
   {
     "path": "../test/results/DCEmodels",
     "filename": "TestResults_models_MJT_UoEdinburgh_UK_etofts.csv",
     "category": "DCEmodels",
     "method": "etofts",
-    "author": "MJT_UoEdinburgh_UK"
+    "author": "MJT_UoEdinburgh_UK",
+    "fitting_method": ""
   },
   {
     "path": "../test/results/DCEmodels",
     "filename": "TestResults_models_MJT_UoEdinburgh_UK_patlak.csv",
     "category": "DCEmodels",
     "method": "patlak",
-    "author": "MJT_UoEdinburgh_UK"
+    "author": "MJT_UoEdinburgh_UK",
+    "fitting_method": ""
   },
   {
     "path": "../test/results/DCEmodels",
     "filename": "TestResults_models_MJT_UoEdinburgh_UK_patlak_llsq.csv",
     "category": "DCEmodels",
     "method": "patlak",
-    "author": "MJT_UoEdinburgh_UK_llsq"
+    "author": "MJT_UoEdinburgh_UK",
+    "fitting_method": "LLSQ"
   },
   {
     "path": "../test/results/DCEmodels",
     "filename": "TestResults_models_MJT_UoEdinburgh_UK_tofts.csv",
     "category": "DCEmodels",
     "method": "tofts",
-    "author": "MJT_UoEdinburgh_UK"
+    "author": "MJT_UoEdinburgh_UK",
+    "fitting_method": ""
   },
   {
     "path": "../test/results/DCEmodels",
     "filename": "TestResults_models_OG_MO_AUMC_ICR_RMH_NL_UK_etofts.csv",
     "category": "DCEmodels",
     "method": "etofts",
-    "author": "OG_MO_AUMC_NL_ICR_RMH_UK"
+    "author": "OG_MO_AUMC_NL_ICR_RMH_UK",
+    "fitting_method": ""
   },
   {
     "path": "../test/results/DCEmodels",
     "filename": "TestResults_models_OGJ_OsloU_NOR_2CXM_LLSQ.csv",
     "category": "DCEmodels",
     "method": "2CXM",
-    "author": "OGJ_OsloU_Norway"
+    "author": "OGJ_OsloU_Norway",
+    "fitting_method": "LLSQ"
   },
   {
     "path": "../test/results/DCEmodels",
     "filename": "TestResults_models_OGJ_OsloU_NOR_etofts_LLSQ.csv",
     "category": "DCEmodels",
     "method": "etofts",
-    "author": "OGJ_OsloU_Norway_LLSQ"
+    "author": "OGJ_OsloU_Norway",
+    "fitting_method": "LLSQ"
   },
   {
     "path": "../test/results/DCEmodels",
     "filename": "TestResults_models_OGJ_OsloU_NOR_etofts_NLLS.csv",
     "category": "DCEmodels",
     "method": "etofts",
-    "author": "OGJ_OsloU_Norway_NLLS"
+    "author": "OGJ_OsloU_Norway",
+    "fitting_method": "NLLS"
   },
   {
     "path": "../test/results/DCEmodels",
     "filename": "TestResults_models_OGJ_OsloU_NOR_tofts_LLSQ.csv",
     "category": "DCEmodels",
     "method": "tofts",
-    "author": "OGJ_OsloU_Norway_LLSQ"
+    "author": "OGJ_OsloU_Norway",
+    "fitting_method": "LLSQ"
   },
   {
     "path": "../test/results/DCEmodels",
     "filename": "TestResults_models_OGJ_OsloU_NOR_tofts_NLLS.csv",
     "category": "DCEmodels",
     "method": "tofts",
-    "author": "OGJ_OsloU_Norway_NLLS"
+    "author": "OGJ_OsloU_Norway",
+    "fitting_method": "NLLS"
   },
   {
     "path": "../test/results/DCEmodels",
     "filename": "TestResults_models_ST_USyd_AUS_etofts.csv",
     "category": "DCEmodels",
     "method": "etofts",
-    "author": "ST_USyd_Aus"
+    "author": "ST_USyd_Aus",
+    "fitting_method": ""
   },
   {
     "path": "../test/results/DCEmodels",
     "filename": "TestResults_models_ST_USyd_AUS_patlak.csv",
     "category": "DCEmodels",
     "method": "patlak",
-    "author": "ST_USyd_Aus"
+    "author": "ST_USyd_Aus",
+    "fitting_method": ""
   },
   {
     "path": "../test/results/DCEmodels",
     "filename": "TestResults_models_ST_USyd_AUS_tofts.csv",
     "category": "DCEmodels",
     "method": "tofts",
-    "author": "ST_USyd_Aus"
+    "author": "ST_USyd_Aus",
+    "fitting_method": ""
   },
-    {
+  {
     "path": "../test/results/DSCmodels",
     "filename": "TestResults_ParamEstimation_SR_TBG_BNI_USAPhoenix_USA.csv",
     "category": "DSCmodels",
     "method": "",
-    "author": "SR_LB_TBG_BNI_USAPhoenix_USA_LCC SFTR"
+    "author": "SR_LB_TBG_BNI_USAPhoenix_USA_LCC SFTR",
+    "fitting_method": ""
   }
 ]


### PR DESCRIPTION
Resolves #86.

- Added `fitting_method` to `results-meta.json` to properly categorize LLSQ vs NLLS.
- Cleaned up author names (e.g., `OGJ_OsloU_Norway_LLSQ` -> `OGJ_OsloU_Norway`).
- Updated `plotting_results_nb.py` and all 10 `.ipynb` model notebooks to properly unpack the new field and display separate entries in plots using `contribution_id`.
